### PR TITLE
Call GetLastError only when ResultCode is FAILED

### DIFF
--- a/Src/API.cs
+++ b/Src/API.cs
@@ -119,7 +119,15 @@ namespace SAE.J2534
         }
         internal void CheckResult(ResultCode Result)
         {
-            if (Result.IsNotOK()) throw new J2534Exception(Result, GetLastError());
+            if (Result.IsOK())
+            {
+                return;
+            }
+            if (Result == ResultCode.FAILED)
+            {
+                throw new J2534Exception(Result, GetLastError());
+            }
+            throw new J2534Exception(Result);
         }
 
         internal string GetLastError()  //Should never be called outside of API_LOCK

--- a/Src/Definitions/ResultCode.cs
+++ b/Src/Definitions/ResultCode.cs
@@ -65,7 +65,7 @@ namespace SAE.J2534
         INVALID_IOCTL_VALUE = 0x05,
         [Description("Flags bit field(s) contain(s) an invalid value.")]
         INVALID_FLAGS = 0x06,
-        [Description("Unspecified error, use PassThruGetLastError for obtaining error text string.")]
+        [Description("Unspecified error")]
         FAILED = 0x07,
         [Description("The PassThru device is not connected to the PC.")]
         DEVICE_NOT_CONNECTED = 0x08,


### PR DESCRIPTION
According to specifications, `GetLastError` should only be called when an API return ERR_FAILED, for other errors `GetLastError` should not be called.